### PR TITLE
Redirects and logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,22 +118,22 @@ ENV LUA_CPATH="/usr/local/openresty/site/lualib/?.so;/usr/local/openresty/lualib
 
 RUN luarocks install lua-resty-woothee
 
-RUN mkdir /data
+RUN mkdir -p /data
 
 # PAXCTL
 RUN apk update && apk add paxctl && paxctl -c $(which nginx) && paxctl -p -e -m -r -x -s $(which nginx)
 RUN paxctl -c /usr/local/openresty/bin/openresty && paxctl -p -e -m -r -x -s /usr/local/openresty/bin/openresty
 
-COPY cert.pem /data/cert.pem
-COPY cert.key /data/cert.key
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
-
-RUN mkdir -p /var/log/nginx/
-
 # Logrotate
 RUN apk add --update logrotate
 RUN mkdir -p /etc/logrotate.d/
 COPY nginx-logrotate.conf /etc/logrotate.d/nginx-logrotate.conf
+
+# Own files
+COPY cert.pem /data/cert.pem
+COPY cert.key /data/cert.key
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+RUN mkdir -p /var/log/nginx/
 
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,9 @@ http {
 
   # Reuse redis connection
   init_worker_by_lua_block {
-    redis = require("resty.redis");
+    redis        = require("resty.redis");
+    idle_timeout = 10000;
+    pool_size    = 100; -- Expected concurrency requests / workers (1000 / 10 = 100)
   }
 
   # wispro web
@@ -146,7 +148,6 @@ http {
         local red = redis:new()
         red:set_timeout(5000)
 
-        -- Aca hay que ver como puta obtenemos la ip del bmu
         local file, err = io.open('/app/public/assets/first_lan_ip', 'r')
         local mark_as_seen_url = 'http://google.com'
 
@@ -164,7 +165,7 @@ http {
 
         local ok, err = red:auth("6ce55d63c1008b02c0079cccd9c3e42720e756b521e5ddb0405b9caf0b373b2d")
         if not ok or err then
-          red:set_keepalive(10000, 100)
+          red:set_keepalive(idle_timeout, pool_size)
 
           ngx.log(ngx.ERR, "failed auth on redis", err)
 
@@ -174,7 +175,7 @@ http {
         local url_list, err = red:lrange(ngx.var.remote_addr, 0, 0)
 
         if not url_list or url_list == ngx.null or not url_list[1] or url_list[1] == ngx.null then
-          red:set_keepalive(10000, 100)
+          red:set_keepalive(idle_timeout, pool_size)
 
           ngx.log(ngx.ERR, "failed to get key " .. ngx.var.remote_addr .. " in redis: ", err)
           return ngx.redirect(mark_as_seen_url, 307)
@@ -186,7 +187,7 @@ http {
           back_url = "https://www.google.com"
         end
 
-        red:set_keepalive(10000, 100)
+        red:set_keepalive(idle_timeout, pool_size)
 
         return ngx.redirect(url_list[1] .. "&back_url=" .. back_url, 307)
       }

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,7 @@ http {
     }
 
     location /ping {
-      return 200 'PONG';
+      return 200 "PONG";
     }
 
     location /assets/ {
@@ -141,15 +141,15 @@ http {
           string.find(user_agent:lower(), ".*captive.*")
         )
 
-        if not its_a_browser then
-          return ngx.exit(404)
+        if ngx.req.get_method() ~= "GET" or not its_a_browser then
+          return ngx.exit(503)
         end
 
         local red = redis:new()
         red:set_timeout(5000)
 
-        local file, err = io.open('/app/public/assets/first_lan_ip', 'r')
-        local mark_as_seen_url = 'http://google.com'
+        local file, err = io.open("/app/public/assets/first_lan_ip", "r")
+        local mark_as_seen_url = "http://google.com"
 
         if file then
           local ip = file:read()

--- a/nginx.conf
+++ b/nginx.conf
@@ -183,7 +183,7 @@ http {
 
         local back_url, err = ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.request_uri
 
-        if error or string.find(back_url:lower(), ".*generate_204.*") then
+        if err or string.find(back_url:lower(), ".*generate_204.*") then
           back_url = "https://www.google.com"
         end
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,11 @@ http {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+  # Reuse redis connection
+  init_worker_by_lua_block {
+    redis = require("resty.redis");
+  }
+
   # wispro web
   upstream wispro {
     server unix:///app/sockets/server.sock fail_timeout=0 max_fails=0;
@@ -111,6 +116,8 @@ http {
   # Redirections
   server {
     listen 85;
+    keepalive_timeout 10;
+    lua_code_cache on;
 
     location / {
       add_header Cache-Control "no-store, no-cache, must-revalidate";
@@ -136,17 +143,6 @@ http {
           return ngx.exit(404)
         end
 
-        local close_redis = function (red)
-          local ok, err = red:set_keepalive(10000, 100)
-
-          ngx.log(ngx.ERR, "Keep alive", ok)
-          if not ok then
-            ngx.log(ngx.ERR, "Error cerrando vieja", err)
-            red:close()
-          end
-        end
-
-        local redis = require "resty.redis"
         local red = redis:new()
         red:set_timeout(5000)
 
@@ -168,7 +164,7 @@ http {
 
         local ok, err = red:auth("6ce55d63c1008b02c0079cccd9c3e42720e756b521e5ddb0405b9caf0b373b2d")
         if not ok or err then
-          close_redis(red)
+          red:set_keepalive(10000, 100)
 
           ngx.log(ngx.ERR, "failed auth on redis", err)
 
@@ -178,7 +174,7 @@ http {
         local url_list, err = red:lrange(ngx.var.remote_addr, 0, 0)
 
         if not url_list or url_list == ngx.null or not url_list[1] or url_list[1] == ngx.null then
-          close_redis(red)
+          red:set_keepalive(10000, 100)
 
           ngx.log(ngx.ERR, "failed to get key " .. ngx.var.remote_addr .. " in redis: ", err)
           return ngx.redirect(mark_as_seen_url, 307)
@@ -190,7 +186,7 @@ http {
           back_url = "https://www.google.com"
         end
 
-        close_redis(red)
+        red:set_keepalive(10000, 100)
 
         return ngx.redirect(url_list[1] .. "&back_url=" .. back_url, 307)
       }

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,6 +46,10 @@ http {
       return 403;
     }
 
+    location /ping {
+      return 200 'PONG';
+    }
+
     location /assets/ {
       expires max;
       add_header Cache-Control public;
@@ -112,7 +116,7 @@ http {
       add_header Cache-Control "no-store, no-cache, must-revalidate";
       expires -1;
 
-      access_by_lua '
+      access_by_lua_block {
         local woothee = require "resty.woothee"
         local user_agent = ngx.var.http_user_agent or ""
         local browser = woothee.parse(user_agent)
@@ -132,33 +136,64 @@ http {
           return ngx.exit(404)
         end
 
+        local close_redis = function (red)
+          local ok, err = red:set_keepalive(10000, 100)
+
+          ngx.log(ngx.ERR, "Keep alive", ok)
+          if not ok then
+            ngx.log(ngx.ERR, "Error cerrando vieja", err)
+            red:close()
+          end
+        end
+
         local redis = require "resty.redis"
         local red = redis:new()
         red:set_timeout(5000)
 
-        local ok, err = red:connect("127.0.0.1", 6379)
-        if not ok then
-          return ngx.exit(404)
+        -- Aca hay que ver como puta obtenemos la ip del bmu
+        local file, err = io.open('/app/public/assets/first_lan_ip', 'r')
+        local mark_as_seen_url = 'http://google.com'
+
+        if file then
+          local ip = file:read()
+          mark_as_seen_url = "http://" .. ip .. "/contract_notifications/blank/mark_as_seen"
         end
 
-        red:auth("6ce55d63c1008b02c0079cccd9c3e42720e756b521e5ddb0405b9caf0b373b2d")
+        local ok, err = red:connect("127.0.0.1", 6379)
+        if not ok or err then
+          ngx.log(ngx.ERR, "failed connect to redis", err)
+
+          return ngx.redirect(mark_as_seen_url, 307)
+        end
+
+        local ok, err = red:auth("6ce55d63c1008b02c0079cccd9c3e42720e756b521e5ddb0405b9caf0b373b2d")
+        if not ok or err then
+          close_redis(red)
+
+          ngx.log(ngx.ERR, "failed auth on redis", err)
+
+          return ngx.redirect(mark_as_seen_url, 307)
+        end
 
         local url_list, err = red:lrange(ngx.var.remote_addr, 0, 0)
 
         if not url_list or url_list == ngx.null or not url_list[1] or url_list[1] == ngx.null then
-          red:close()
-          return ngx.exit(404)
+          close_redis(red)
+
+          ngx.log(ngx.ERR, "failed to get key " .. ngx.var.remote_addr .. " in redis: ", err)
+          return ngx.redirect(mark_as_seen_url, 307)
         end
 
         local back_url, err = ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.request_uri
 
-        if string.find(back_url:lower(), ".*generate_204.*") then
+        if error or string.find(back_url:lower(), ".*generate_204.*") then
           back_url = "https://www.google.com"
         end
 
-        red:close()
+        close_redis(red)
+
         return ngx.redirect(url_list[1] .. "&back_url=" .. back_url, 307)
-      ';
+      }
     }
   }
 }


### PR DESCRIPTION
- Metemos nuevamente los logs en casos de error.
- Activamos el cache de código en lua
- Seteamos keepalive para reutilizar la conexión.